### PR TITLE
fix: application_link_oracle_request uint64 values handling

### DIFF
--- a/database/profiles.go
+++ b/database/profiles.go
@@ -364,7 +364,14 @@ WHERE application_link_oracle_request.height <= excluded.height`
 		return fmt.Errorf("error while serializing oracle request call data: %s", err)
 	}
 
-	_, err = db.Sql.Exec(stmt, linkID, request.ID, request.OracleScriptID, string(callDataBz), request.ClientID, height)
+	_, err = db.Sql.Exec(stmt,
+		linkID,
+		fmt.Sprintf("%d", request.ID),
+		fmt.Sprintf("%d", request.OracleScriptID),
+		string(callDataBz),
+		request.ClientID,
+		height,
+	)
 	return err
 }
 

--- a/database/schema/01-profiles.sql
+++ b/database/schema/01-profiles.sql
@@ -90,8 +90,8 @@ CREATE TABLE application_link_oracle_request
 (
     id                  SERIAL NOT NULL PRIMARY KEY,
     application_link_id BIGINT NOT NULL REFERENCES application_link (id) ON DELETE CASCADE,
-    request_id          BIGINT NOT NULL,
-    script_id           BIGINT NOT NULL,
+    request_id          TEXT   NOT NULL,
+    script_id           TEXT   NOT NULL,
     call_data           JSONB  NOT NULL,
     client_id           TEXT   NOT NULL,
     height              BIGINT NOT NULL,


### PR DESCRIPTION
## Description

This PR updates how the `application_link_oracle_request` uint64 values are stored inside the database by using `TEXT` instead of `BIGINT` to avoid the following error: 
```
uint64 values with high bit set are not supported
```

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)