### PR TITLE
fix: remove profile references from relationships and blocks tables

### DIFF
--- a/database/schema/03-relationships.sql
+++ b/database/schema/03-relationships.sql
@@ -1,7 +1,7 @@
 CREATE TABLE user_relationship
 (
-    creator_address      TEXT   NOT NULL REFERENCES profile (address) ON DELETE CASCADE,
-    counterparty_address TEXT   NOT NULL REFERENCES profile (address) ON DELETE CASCADE,
+    creator_address      TEXT   NOT NULL,
+    counterparty_address TEXT   NOT NULL,
     subspace_id          BIGINT NOT NULL REFERENCES subspace (id) ON DELETE CASCADE,
     height               BIGINT NOT NULL,
     CONSTRAINT unique_relationship UNIQUE (creator_address, counterparty_address, subspace_id)
@@ -9,8 +9,8 @@ CREATE TABLE user_relationship
 
 CREATE TABLE user_block
 (
-    blocker_address TEXT   NOT NULL REFERENCES profile (address) ON DELETE CASCADE,
-    blocked_address TEXT   NOT NULL REFERENCES profile (address) ON DELETE CASCADE,
+    blocker_address TEXT,
+    blocked_address TEXT,
     reason          TEXT,
     subspace_id     BIGINT NOT NULL REFERENCES subspace (id) ON DELETE CASCADE,
     height          BIGINT NOT NULL,

--- a/x/relationships/external.go
+++ b/x/relationships/external.go
@@ -2,6 +2,7 @@ package relationships
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/types/query"
 	relationshipstypes "github.com/desmos-labs/desmos/v4/x/relationships/types"
@@ -15,12 +16,12 @@ import (
 func (m *Module) RefreshRelationshipsData(height int64, subspaceID uint64) error {
 	relationships, err := m.queryAllRelationships(height, subspaceID)
 	if err != nil {
-		return err
+		return fmt.Errorf("error while getting relationships from gRPC: %s", err)
 	}
 
 	err = m.db.DeleteAllRelationships(height, subspaceID)
 	if err != nil {
-		return err
+		return fmt.Errorf("error while deleting relationships: %s", err)
 	}
 
 	for _, relationship := range relationships {
@@ -29,7 +30,7 @@ func (m *Module) RefreshRelationshipsData(height int64, subspaceID uint64) error
 
 		err = m.db.SaveRelationship(relationship)
 		if err != nil {
-			return err
+			return fmt.Errorf("error while saving relationship: %s", err)
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR removes the foreign key constraint from the `user_block` and `user_relationship` table as on Desmos there is no need to have a profile to block/be blocked or be the creator/counterparty of a relationship. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)