### PR TITLE
feat: add support for messages filtering

### DIFF
--- a/.docs/config.md
+++ b/.docs/config.md
@@ -1,153 +1,135 @@
 ## Configuration
-The default `config.toml` file should look like the following: 
+The default `config.yaml` file should look like the following:
 
 <details>
 
-<summary>Default config.toml file</summary>
+<summary>Example config.yaml file</summary>
 
-```toml
-[cosmos]
-modules = []
-prefix = "cosmos"
+```yaml
+chain:
+  bech32_prefix: desmos
+  modules:
+    - authz
+    - fees
+    - profiles
+    - relationships
+    - subspaces
+    - posts
+    - reactions
+    - reports
+    - contracts
+    - notifications
 
-[rpc]
-address = "http://localhost:26657"
-client_name = "juno"
+node:
+  type: remote
+  config:
+    rpc:
+      client_name: djuno
+      address: https://rpc.morpheus.desmos.network:443
+      max_connections: 10
 
-[grpc]
-address = "localhost:9090"
-insecure = true
+    grpc:
+      address: https://grpc.morpheus.desmos.network:443
+      insecure: false
 
-[parsing]
-fast_sync = true
-listen_new_blocks = true
-parse_genesis = true
-parse_old_blocks = true
-start_height = 1
-workers = 1
+parsing:
+  workers: 1
+  listen_new_blocks: true
+  parse_old_blocks: true
+  start_height: 1
 
-[database]
-host = "localhost"
-max_idle_connections = 0
-max_open_connections = 0
-name = "database-name"
-password = "password"
-port = 5432
-schema = "public"
-ssl_mode = ""
-user = "user"
+database:
+  name: djuno
+  host: localhost
+  port: 5432
+  user: user
+  password: password
+  max_open_connections: 15
+  max_idle_connections: 10
 
-[pruning]
-interval = 10
-keep_every = 500
-keep_recent = 100
+logging:
+  level: debug
+  format: text
 
-[notifications]
-  firebase_credentials_file = ""
-  firebase_project_id = ""
+contracts:
+  tips:
+    code_id: 11
 
-[logging]
-format = "text"
-level = "debug"
+notifications:
+  firebase_credentials_file_path: /path/to/firebase-service-account.json
+  firebase_project_id: firebase-project-id
+  android_channel_id: general
+
+filters:
+  supported_subspace_ids: [ 5 ]
 ```
 
 </details>
 
-Let's see what each section refers to: 
+## `chain`
+This section contains the details of the chain configuration.
 
-- [`cosmos`](#cosmos)
-- [`rpc`](#rpc)
-- [`grpc`](#grpc)
-- [`parsing`](#parsing)
-- [`database`](#database)
-- [`pruning`](#pruning)
-- [`notifications`](#notifications)
-- [`logging`](#logging)
-
-## `cosmos`
-This section contains the details of the chain configuration regarding the Cosmos SDK.
-
-| Attribute |   Type   | Description                            | Example                              |
-|:---------:|:--------:|:---------------------------------------|:-------------------------------------|
-| `modules` | `array`  | List of modules that should be enabled | `[ "auth", "bank", "distribution" ]` |
-| `prefix`  | `string` | Bech 32 prefix of the addresses        | `cosmos`                             | 
+| Attribute        |   Type   | Description                            | 
+|:-----------------|:--------:|:---------------------------------------|
+| `modules`        | `array`  | List of modules that should be enabled |
+| `bech32_prefix`  | `string` | Bech32 prefix of the addresses         | 
 
 ### Supported modules
-Currently we support the followings Cosmos modules:
-- `auth` to parse the `x/auth` data
-- `bank` to parse the `x/bank` data
-- `consensus` to parse the consensus data 
-- `distribution` to parse the `x/distribution` data
-- `gov` to parse the `x/gox` data 
-- `mint` to parse the `x/mint` data
-- `modules` to get the list of enabled modules inside DJuno
-- `pricefeed` to get the token prices
-- `slashing` to parse the `x/slashing` data
-- `staking` to parse the `x/staking` data
+Currently we support the followings Desmos and Cosmos SDK modules:
 
-## `rpc`
-This section contains the details of the chain RPC to which DJuno will connect. 
+- `authz` to parse the data related to the Cosmos SDK `x/authz` module
+- `feegrant` to parse the data related to the Cosmos SDK `x/feegrants` module
+- `fees` to parse the data related to the Desmos `x/fees` module
+- `profiles` to parse the data related to the Desmos `x/profiles` module
+- `relationships` to parse the data related to the Desmos `x/relationships` module
+- `subspaces` to parse the data related to the Desmos `x/subspaces` module
+- `posts` to parse the data related to the Desmos `x/posts` module
+- `reactions` to parse the data related to the Desmos `x/reactions` module
+- `reports` to parse the data related to the Desmos `x/reports` module
+- `contracts` to parse the data related to smart contracts
 
-|   Attribute   |   Type   | Description                                                   | Example                  |
-|:-------------:|:--------:|:--------------------------------------------------------------|:-------------------------|
-|   `address`   | `string` | Address of the RPC endpoint                                   | `http://localhost:26657` |
-| `client_name` | `string` | Client name used when subscribing to the Tendermint websocket | `bdjuno`                 |
-
-## `grpc` 
-This section contains the details of the gRPC endpoint that DJuno will use to query the data.
-
-| Attribute  |   Type    | Description                                  | Example          |
-|:----------:|:---------:|:---------------------------------------------|:-----------------|
-| `address`  | `string`  | Address of the gRPC endpoint                 | `localhost:9090` |
-| `insecure` | `boolean` | Whether the gRPC endpoint is insecure or not | `false`          |
+## `node`
+This section contains the details of the chain node to be used in order to fetch the data.
+You can reference [this page](https://github.com/forbole/juno/blob/cosmos/v0.44.x/.docs/config.md#node) for more
+details.
 
 ## `parsing`
+This section determines how the data will be parsed. You can
+reference [this page](https://github.com/forbole/juno/blob/cosmos/v0.44.x/.docs/config.md#parsing) for more details.
 
-|      Attribute      |   Type    | Description                                                                          | Example  |
-|:-------------------:|:---------:|:-------------------------------------------------------------------------------------|:---------|
-|     `fast_sync`     | `boolean` | Whether DJuno should use the fast sync abilities of different modules when enabled   | `false`  |
-| `listen_new_blocks` | `boolean` | Whether DJuno should parse new blocks as soon as they get created                    | `true`   | 
-|   `parse_genesis`   | `boolean` | Whether DJuno needs to parse the genesis state or not                                | `true`   |
-| `parse_old_blocks`  | `boolean` | Whether DJuno should parse old chain blocks or not                                   | `true`   | 
-|   `start_height`    | `integer` | Height at which DJuno should start parsing old blocks                                | `250000` | 
-|      `workers`      | `integer` | Number of works that will be used to fetch the data and store it inside the database | `5`      |
+## `database`
+This section contains all the different configuration related to the PostgreSQL database where DJuno will write the
+data. You can reference [this page](https://github.com/forbole/juno/blob/cosmos/v0.44.x/.docs/config.md#database) for
+more details.
 
-## `database` 
-This section contains all the different configuration related to the PostgreSQL database where DJuno will write the data. 
+## `logging`
+This section allows to configure the logging details of DJuno. You can
+reference [this page](https://github.com/forbole/juno/blob/cosmos/v0.44.x/.docs/config.md#logging) for more details.
 
-|       Attribute        |   Type    | Description                                                                                                                                               | Example     |
-|:----------------------:|:---------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------|:------------|
-|         `host`         | `string`  | Host where the database is found                                                                                                                          | `localhost` | 
-|         `port`         | `integer` | Port to be used to connect to the PostgreSQL instance                                                                                                     | `5432`      |
-|         `name`         | `string`  | Name of the database to which connect to                                                                                                                  | `bdjuno`    | 
-|         `user`         | `string`  | Name of the user to use when connecting to the database. This user must have read/write access to all the database.                                       | `bdjuno`    | 
-|       `password`       | `string`  | Password to be used to connect to the database instance                                                                                                   | `password`  | 
-|        `schema`        | `string`  | Schema to be used inside the database (default: `public`)                                                                                                 | `public`    | 
-|       `ssl_mode`       | `string`  | [PostgreSQL SSL mode](https://www.postgresql.org/docs/9.1/libpq-ssl.html) to be used when connecting to the database. If not set, `disable` will be used. | `verify-ca` |
-| `max_idle_connections` | `integer` | Max number of idle connections that should be kept open (default: `1`)                                                                                    | `10`        |
-| `max_open_connections` | `integer` | Max number of open connections at any time (default: `1`)                                                                                                 | `15`        | 
+## `contracts`
+If the `contracts` module is enabled, you can use this section to customize some data about the smart contracts that
+will be parsed.
 
-## `pruning`
-This section contains the configuration about the pruning options of the database. Note that this will have effect only if you add the `"pruning"` entry to the `modules` field of the [`cosmos` config](#cosmos). 
+### `tips`
+This section defines the details about the tips smart contract that should be parsed
 
-|   Attribute   |   Type    | Description                                                                                            | Example |
-|:-------------:|:---------:|:-------------------------------------------------------------------------------------------------------|:--------|
-|  `interval`   | `integer` | Number of blocks that should pass between one pruning and the other (default: prune every `10` blocks) | `100`   | 
-| `keep_every`  | `integer` | Keep the state every `nth` block, even if it should have been pruned                                   | `500`   | 
-| `keep_recent` | `integer` | Do not prune this amount of recent states                                                              | `100`   |
+| Attribute       |   Type    | Description                                                    | 
+|:----------------|:---------:|:---------------------------------------------------------------|
+| `code_id`       | `integer` | On-chan code id referring the tips smart contract to be parsed |
 
 ## `notifications`
-This sections allows to configure the push notifications that will be sent to applications.
+If the `notifications` module is enabled, you can use this section to define some details about how notifications will
+be sent to clients.
 
-|          Attribute          |   Type   | Description                                                                                                            | Example                            |
-|:---------------------------:|:--------:|:-----------------------------------------------------------------------------------------------------------------------|:-----------------------------------|
-| `firebase_credentials_file` | `string` | Absolute path to the [Firebase credential file](https://firebase.google.com/docs/admin/setup#add_firebase_to_your_app) | `/home/ubuntu/djuno/firebase.json` |
-|    `firebase_project_id`    | `string` | ID of your [Firebase project](https://firebase.google.com/docs/projects/learn-more#project-id)                         | `PROJECT_ID`                       |
+| Attribute                         |   Type   | Description                                                                                | 
+|:----------------------------------|:--------:|:-------------------------------------------------------------------------------------------|
+| `firebase_credentials_file_path`  | `string` | Path to the JSON file containing the Firebase credentials                                  |
+| `firebase_project_id`             | `string` | Id of the Firebase project that should be used to send the notifications                   | 
+| `android_channel_id`              | `string` | Id of the notifications channel that should be used when sending out Android notifications | 
 
-## `logging` 
-This section allows to configure the logging details of DJuno. 
+## `filters`
+If present, this section contains the details about how messages will be filtered before being parsed.
 
-| Attribute |   Type   | Description                                                             | Example |
-|:---------:|:--------:|:------------------------------------------------------------------------|:--------|
-| `format`  | `string` | Format in which the logs should be output (either `json` or `text`)     | `json`  | 
-|  `level`  | `string` | Level of the log (either `verbose`, `debug`, `info`, `warn` or `error`) | `error` | 
+| Attribute                      |   Type   | Description                                         | 
+|:-------------------------------|:--------:|:----------------------------------------------------|
+| `supported_subspace_ids`       | `array`  | List of subspace id for which to parse the messages |

--- a/.docs/setup.md
+++ b/.docs/setup.md
@@ -1,11 +1,11 @@
 # Setup 
 Setting up DJuno is pretty straightforward. It requires three things to be done:
 1. Install DJuno.
-1. Initialize the configuration. 
-2. Start the parser. 
+2. Initialize the configuration. 
+3. Start the parser. 
 
 ## Installing DJuno
-In order to install DJuno you are required to have [Go 1.15+](https://golang.org/dl/) installed on your machine. Once you have it, the first thing to do is to clone the GitHub repository. To do this you can run
+In order to install DJuno you are required to have [Go 1.18+](https://golang.org/dl/) installed on your machine. Once you have it, the first thing to do is to clone the GitHub repository. To do this you can run
 
 ```shell
 $ git clone https://github.com/desmos-labs/djuno.git
@@ -61,7 +61,7 @@ $ djuno init --home /path/to/my/folder
 Once the file is created, you are required to edit it and change the different values. To do this you can run 
 
 ```shell
-$ nano ~/.djuno/config.toml
+$ nano ~/.djuno/config.yaml
 ```
 
 For a better understanding of what each section and field refers to, please read the [config reference](config.md). 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/cobra v1.6.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tendermint/tendermint v0.34.21
-	google.golang.org/api v0.99.0
+	google.golang.org/api v0.100.0
 	google.golang.org/grpc v1.50.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -129,7 +129,7 @@ require (
 	github.com/google/orderedcode v0.0.1 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
-	github.com/googleapis/gax-go/v2 v2.5.1 // indirect
+	github.com/googleapis/gax-go/v2 v2.6.0 // indirect
 	github.com/gordonklaus/ineffassign v0.0.0-20210914165742-4cc7213b9bc8 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
@@ -263,8 +263,8 @@ require (
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/exp/typeparams v0.0.0-20220827204233-334a2380cb91 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/net v0.0.0-20221012135044-0b7e1fb9d458 // indirect
-	golang.org/x/oauth2 v0.0.0-20221006150949-b44042a4b9c1 // indirect
+	golang.org/x/net v0.0.0-20221014081412-f15817d10f9b // indirect
+	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 // indirect
 	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0 // indirect
 	golang.org/x/sys v0.0.0-20220915200043-7b5979e65e41 // indirect
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 // indirect
@@ -273,7 +273,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/appengine/v2 v2.0.2 // indirect
-	google.golang.org/genproto v0.0.0-20221010155953-15ba04fc1c0e // indirect
+	google.golang.org/genproto v0.0.0-20221014213838-99cd37c6964a // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
-github.com/googleapis/gax-go/v2 v2.5.1 h1:kBRZU0PSuI7PspsSb/ChWoVResUcwNVIdpB049pKTiw=
-github.com/googleapis/gax-go/v2 v2.5.1/go.mod h1:h6B0KMMFNtI2ddbGJn3T3ZbwkeT6yqEF02fYlzkUCyo=
+github.com/googleapis/gax-go/v2 v2.6.0 h1:SXk3ABtQYDT/OH8jAyvEOQ58mgawq5C4o/4/89qN2ZU=
+github.com/googleapis/gax-go/v2 v2.6.0/go.mod h1:1mjbznJAPHFpesgE5ucqfYEscaz5kMdcIDwU/6+DDoY=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gordonklaus/ineffassign v0.0.0-20210914165742-4cc7213b9bc8 h1:PVRE9d4AQKmbelZ7emNig1+NT27DUmKZn5qXxfio54U=
@@ -1477,8 +1477,8 @@ golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220708220712-1185a9018129/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20221012135044-0b7e1fb9d458 h1:MgJ6t2zo8v0tbmLCueaCbF1RM+TtB0rs3Lv8DGtOIpY=
-golang.org/x/net v0.0.0-20221012135044-0b7e1fb9d458/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20221014081412-f15817d10f9b h1:tvrvnPFcdzp294diPnrdZZZ8XUt2Tyj7svb7X52iDuU=
+golang.org/x/net v0.0.0-20221014081412-f15817d10f9b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1497,8 +1497,8 @@ golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
-golang.org/x/oauth2 v0.0.0-20221006150949-b44042a4b9c1 h1:3VPzK7eqH25j7GYw5w6g/GzNRc0/fYtrxz27z1gD4W0=
-golang.org/x/oauth2 v0.0.0-20221006150949-b44042a4b9c1/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
+golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 h1:nt+Q6cXKz4MosCSpnbMtqiQ8Oz0pxTef2B4Vca2lvfk=
+golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1780,8 +1780,8 @@ google.golang.org/api v0.61.0/go.mod h1:xQRti5UdCmoCEqFxcz93fTl338AVqDgyaDRuOZ3h
 google.golang.org/api v0.63.0/go.mod h1:gs4ij2ffTRXwuzzgJl/56BdwJaA194ijkfn++9tDuPo=
 google.golang.org/api v0.67.0/go.mod h1:ShHKP8E60yPsKNw/w8w+VYaj9H6buA5UqDp8dhbQZ6g=
 google.golang.org/api v0.70.0/go.mod h1:Bs4ZM2HGifEvXwd50TtW70ovgJffJYw2oRCOFU/SkfA=
-google.golang.org/api v0.99.0 h1:tsBtOIklCE2OFxhmcYSVqGwSAN/Y897srxmcvAQnwK8=
-google.golang.org/api v0.99.0/go.mod h1:1YOf74vkVndF7pG6hIHuINsM7eWwpVTAfNMNiL91A08=
+google.golang.org/api v0.100.0 h1:LGUYIrbW9pzYQQ8NWXlaIVkgnfubVBZbMFb9P8TK374=
+google.golang.org/api v0.100.0/go.mod h1:ZE3Z2+ZOr87Rx7dqFsdRQkRBk36kDtp/h+QpHbB7a70=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1868,8 +1868,8 @@ google.golang.org/genproto v0.0.0-20220126215142-9970aeb2e350/go.mod h1:5CzLGKJ6
 google.golang.org/genproto v0.0.0-20220207164111-0872dc986b00/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220218161850-94dd64e39d7c/go.mod h1:kGP+zUP2Ddo0ayMi4YuN7C3WZyJvGLZRh8Z5wnAqvEI=
 google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf/go.mod h1:kGP+zUP2Ddo0ayMi4YuN7C3WZyJvGLZRh8Z5wnAqvEI=
-google.golang.org/genproto v0.0.0-20221010155953-15ba04fc1c0e h1:halCgTFuLWDRD61piiNSxPsARANGD3Xl16hPrLgLiIg=
-google.golang.org/genproto v0.0.0-20221010155953-15ba04fc1c0e/go.mod h1:3526vdqwhZAwq4wsRUaVG555sVgsNmIjRtO7t/JH29U=
+google.golang.org/genproto v0.0.0-20221014213838-99cd37c6964a h1:GH6UPn3ixhWcKDhpnEC55S75cerLPdpp3hrhfKYjZgw=
+google.golang.org/genproto v0.0.0-20221014213838-99cd37c6964a/go.mod h1:1vXfmgAz9N9Jx0QA82PqRVauvCz1SGSz739p0f183jM=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.19.1/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/x/contracts/tips/config.go
+++ b/x/contracts/tips/config.go
@@ -1,6 +1,8 @@
 package tips
 
-import "gopkg.in/yaml.v3"
+import (
+	"gopkg.in/yaml.v3"
+)
 
 type ContractsConfig struct {
 	Tips *Config `yaml:"tips"`

--- a/x/filters/config.go
+++ b/x/filters/config.go
@@ -1,0 +1,29 @@
+package filters
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	// SupportedSubspaceIDs represents the list of supported subspaces
+	SupportedSubspaceIDs []uint64 `yaml:"supported_subspace_ids"`
+}
+
+// isSubspaceSupported tells whether the given subspace is supported from this config
+func (c *Config) isSubspaceSupported(subspaceID uint64) bool {
+	for _, id := range cfg.SupportedSubspaceIDs {
+		if id == subspaceID {
+			return true
+		}
+	}
+	return false
+}
+
+func ParseConfig(bz []byte) (*Config, error) {
+	type T struct {
+		Config *Config `yaml:"filters,omitempty"`
+	}
+	var cfg T
+	err := yaml.Unmarshal(bz, &cfg)
+	return cfg.Config, err
+}

--- a/x/filters/messages.go
+++ b/x/filters/messages.go
@@ -1,0 +1,39 @@
+package filters
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	subspacestypes "github.com/desmos-labs/desmos/v4/x/subspaces/types"
+	"github.com/forbole/juno/v3/types/config"
+)
+
+var (
+	initialized bool
+	cfg         *Config
+)
+
+// ShouldMsgBeParsed tells whether the given subspace is currently supported and its messages should be parsed
+func ShouldMsgBeParsed(msg sdk.Msg) bool {
+	parseCfg()
+	if subspaceMsg, ok := msg.(subspacestypes.SubspaceMsg); ok && cfg != nil {
+		return cfg.isSubspaceSupported(subspaceMsg.GetSubspaceID())
+	}
+	return true
+}
+
+// parseCfg parses the filter configuration
+func parseCfg() {
+	if initialized {
+		return
+	}
+
+	junoCfgBz, err := config.Cfg.GetBytes()
+	if err != nil {
+		panic(err)
+	}
+	parsedCfg, err := ParseConfig(junoCfgBz)
+	if err != nil {
+		panic(err)
+	}
+	cfg = parsedCfg
+	initialized = true
+}

--- a/x/notifications/config.go
+++ b/x/notifications/config.go
@@ -1,6 +1,8 @@
 package notifications
 
-import "gopkg.in/yaml.v3"
+import (
+	"gopkg.in/yaml.v3"
+)
 
 type Config struct {
 	FirebaseCredentialsFilePath string `yaml:"firebase_credentials_file_path"`

--- a/x/notifications/config.go
+++ b/x/notifications/config.go
@@ -8,7 +8,6 @@ type Config struct {
 	FirebaseCredentialsFilePath string `yaml:"firebase_credentials_file_path"`
 	FirebaseProjectID           string `yaml:"firebase_project_id"`
 	AndroidChannelID            string `yaml:"android_channel_id"`
-	SubspaceID                  uint64 `yaml:"subspace_id"`
 }
 
 func ParseConfig(bz []byte) (*Config, error) {

--- a/x/posts/handle_msg.go
+++ b/x/posts/handle_msg.go
@@ -4,6 +4,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/gogo/protobuf/proto"
 
+	"github.com/desmos-labs/djuno/v2/x/filters"
+
 	poststypes "github.com/desmos-labs/desmos/v4/x/posts/types"
 
 	"github.com/desmos-labs/djuno/v2/types"
@@ -21,7 +23,7 @@ func (m *Module) HandleMsgExec(index int, _ *authz.MsgExec, _ int, executedMsg s
 
 // HandleMsg implements modules.MessageModule
 func (m *Module) HandleMsg(index int, msg sdk.Msg, tx *juno.Tx) error {
-	if len(tx.Logs) == 0 {
+	if len(tx.Logs) == 0 || !filters.ShouldMsgBeParsed(msg) {
 		return nil
 	}
 

--- a/x/profiles/handle_msg.go
+++ b/x/profiles/handle_msg.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/desmos-labs/djuno/v2/x/filters"
+
 	"github.com/cosmos/cosmos-sdk/x/authz"
 
 	"github.com/gogo/protobuf/proto"
@@ -26,7 +28,7 @@ func (m *Module) HandleMsgExec(index int, _ *authz.MsgExec, _ int, executedMsg s
 
 // HandleMsg implements modules.MessageModule
 func (m *Module) HandleMsg(index int, msg sdk.Msg, tx *juno.Tx) error {
-	if len(tx.Logs) == 0 {
+	if len(tx.Logs) == 0 || !filters.ShouldMsgBeParsed(msg) {
 		return nil
 	}
 

--- a/x/reactions/handle_msg.go
+++ b/x/reactions/handle_msg.go
@@ -4,6 +4,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/gogo/protobuf/proto"
 
+	"github.com/desmos-labs/djuno/v2/x/filters"
+
 	reactionstypes "github.com/desmos-labs/desmos/v4/x/reactions/types"
 
 	"github.com/rs/zerolog/log"
@@ -19,7 +21,7 @@ func (m *Module) HandleMsgExec(index int, _ *authz.MsgExec, _ int, executedMsg s
 
 // HandleMsg implements modules.MessageModule
 func (m *Module) HandleMsg(index int, msg sdk.Msg, tx *juno.Tx) error {
-	if len(tx.Logs) == 0 {
+	if len(tx.Logs) == 0 || !filters.ShouldMsgBeParsed(msg) {
 		return nil
 	}
 

--- a/x/relationships/handle_msg.go
+++ b/x/relationships/handle_msg.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/desmos-labs/djuno/v2/x/filters"
+
 	"github.com/cosmos/cosmos-sdk/x/authz"
 
 	"github.com/gogo/protobuf/proto"
@@ -25,7 +27,7 @@ func (m *Module) HandleMsgExec(index int, _ *authz.MsgExec, _ int, executedMsg s
 
 // HandleMsg implements modules.MessageModule
 func (m *Module) HandleMsg(_ int, msg sdk.Msg, tx *juno.Tx) error {
-	if len(tx.Logs) == 0 {
+	if len(tx.Logs) == 0 || !filters.ShouldMsgBeParsed(msg) {
 		return nil
 	}
 

--- a/x/reports/handle_msg.go
+++ b/x/reports/handle_msg.go
@@ -4,6 +4,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/gogo/protobuf/proto"
 
+	"github.com/desmos-labs/djuno/v2/x/filters"
+
 	reportstypes "github.com/desmos-labs/desmos/v4/x/reports/types"
 
 	"github.com/rs/zerolog/log"
@@ -19,7 +21,7 @@ func (m *Module) HandleMsgExec(index int, _ *authz.MsgExec, _ int, executedMsg s
 
 // HandleMsg implements modules.MessageModule
 func (m *Module) HandleMsg(index int, msg sdk.Msg, tx *juno.Tx) error {
-	if len(tx.Logs) == 0 {
+	if len(tx.Logs) == 0 || !filters.ShouldMsgBeParsed(msg) {
 		return nil
 	}
 

--- a/x/subspaces/handle_msg.go
+++ b/x/subspaces/handle_msg.go
@@ -4,6 +4,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/gogo/protobuf/proto"
 
+	"github.com/desmos-labs/djuno/v2/x/filters"
+
 	"github.com/rs/zerolog/log"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -21,7 +23,7 @@ func (m *Module) HandleMsgExec(index int, _ *authz.MsgExec, _ int, executedMsg s
 
 // HandleMsg implements modules.MessageModule
 func (m *Module) HandleMsg(index int, msg sdk.Msg, tx *juno.Tx) error {
-	if len(tx.Logs) == 0 {
+	if len(tx.Logs) == 0 || !filters.ShouldMsgBeParsed(msg) {
 		return nil
 	}
 


### PR DESCRIPTION
## Description

This PR adds support for a new configuration section named `filters` that allows to specify only a subset of subspace ids for which messages will be parsed. This allows a custom DJuno instance to only parse the messages that are related to a single subspace instead of parsing all messages at the same time.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)