### PR TITLE
feat!: improve Firebase notifications building 

### DIFF
--- a/x/notifications/config.go
+++ b/x/notifications/config.go
@@ -7,7 +7,6 @@ import (
 type Config struct {
 	FirebaseCredentialsFilePath string `yaml:"firebase_credentials_file_path"`
 	FirebaseProjectID           string `yaml:"firebase_project_id"`
-	AndroidChannelID            string `yaml:"android_channel_id"`
 	PersistHistory              bool   `yaml:"persist_history"`
 }
 

--- a/x/notifications/message-builder/sender.go
+++ b/x/notifications/message-builder/sender.go
@@ -14,9 +14,6 @@ type FirebaseMessageBuilderCreator func(ctx notificationscontext.Context) Fireba
 type MessageConfig struct {
 	Data         map[string]string
 	Notification *messaging.Notification
-	Android      *messaging.AndroidConfig
-	WebPush      *messaging.WebpushConfig
-	Apple        *messaging.APNSConfig
 }
 
 // FirebaseMessageBuilder represents the interface that allows to build a Firebase message

--- a/x/notifications/message-builder/topic/builder.go
+++ b/x/notifications/message-builder/topic/builder.go
@@ -26,8 +26,5 @@ func (m *MessageBuilder) BuildMessage(recipient string, config *messagebuilder.M
 		Topic:        recipient,
 		Data:         config.Data,
 		Notification: config.Notification,
-		Android:      config.Android,
-		Webpush:      config.WebPush,
-		APNS:         config.Apple,
 	}), nil
 }

--- a/x/notifications/module.go
+++ b/x/notifications/module.go
@@ -114,19 +114,10 @@ func (m *Module) SendNotification(recipient string, notification *messaging.Noti
 	data[notificationsbuilder.ClickActionKey] = notificationsbuilder.ClickActionValue
 	data[notificationsbuilder.RecipientKey] = recipient
 
-	// Build the Android config
-	var androidConfig *messaging.AndroidConfig
-	if notification != nil {
-		androidConfig = &messaging.AndroidConfig{
-			Notification: &messaging.AndroidNotification{ChannelID: m.cfg.AndroidChannelID},
-		}
-	}
-
 	// Build the message
 	message, err := m.messageBuilder.BuildMessage(recipient, &messagebuilder.MessageConfig{
 		Data:         data,
 		Notification: notification,
-		Android:      androidConfig,
 	})
 	if err != nil {
 		return fmt.Errorf("error while building notification message: %s", err)


### PR DESCRIPTION
## Description

This PR improves how the Firebase notification messages are built. Particularly now: 

- the `android_channel_id` is no longer used within the `notifications` module config
- removed the default notification object when creating a Firbease message

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)